### PR TITLE
Build Avro C on FreeBSD

### DIFF
--- a/lang/c/src/codec.c
+++ b/lang/c/src/codec.c
@@ -16,11 +16,18 @@
  */
 
 #include <string.h>
+#include <sys/param.h>
 #ifdef SNAPPY_CODEC
 #include <snappy-c.h>
 #  if defined(__APPLE__)
 #    include <libkern/OSByteOrder.h>
 #    define __bswap_32 OSSwapInt32
+#  elif defined(BSD)
+#    include <sys/types.h>
+#    include <sys/endian.h>
+#    define __bswap_16  bswap16
+#    define __bswap_32  bswap32
+#    define __bswap_64  bswap64
 #  else
 #    include <byteswap.h>
 #  endif

--- a/lang/c/version.sh
+++ b/lang/c/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script is used to generate version numbers for autotools
 #


### PR DESCRIPTION
This patch updates Avro C to build on FreeBSD.  It may build on other BSDs, but it has only been tested on FreeBSD 9.2.
